### PR TITLE
support SSL SNI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,9 @@ pyflakes==0.8.1
 python-ldap==2.4.19
 sqlparse==0.1.14
 six==1.9.0
+pyasn1==0.1.8
+pyOpenSSL==0.15.1
+ndg-httpsclient==0.4.0
 
 djangowind==0.13.3
 sorl==3.1


### PR DESCRIPTION
At some point recently, we deployed SSL certificates to neptune for
non-CCNMTL domains. This uses [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) to get the
correct certificate to the browser.

At this point, SNI is generally well supported enough that most things
just work. Unfortunately, python's built in http/ssl libraries don't support
SNI out of the box. According to this:

http://docs.python-requests.org/en/latest/community/faq/#what-are-hostname-doesn-t-match-errors

and this:

https://stackoverflow.com/questions/18578439/using-requests-with-tls-doesnt-give-sni-support/18579484#18579484

there need to be a couple extra libraries installed for SNI.

Where this hits us is with Sentry. `sentry.ccnmtl.columbia.edu` resolves
to neptune, which is now using SNI. So all of our apps need to be
patched to handle SNI so they can submit errors to Sentry.