### PR TITLE
Optimize Dashboard Rendering

### DIFF
--- a/media/css/main.css
+++ b/media/css/main.css
@@ -885,3 +885,19 @@ margin: 0 7px 0 -2px !important;
 .comp_descriptor .comp_criteria {
     width: 340px;
 }
+
+.dropdown-menu .menu-4 {
+    margin-left: 20px;
+}
+.dropdown-menu .menu-5 {
+    margin-left: 40px;
+}
+.dropdown-menu .menu-6 {
+    margin-left: 60px;
+}
+
+.dropdown-menu .menu-item a:hover {
+    color: #ffffff;
+    text-decoration: none;
+    background-color: #0088cc;
+}

--- a/phtc/templates/main/dashboard.html
+++ b/phtc/templates/main/dashboard.html
@@ -1,81 +1,96 @@
 {% extends 'base.html' %}
+
 {% block title %}My Dashboard{% endblock %}
+
 {% block noleftsidebar %} class="no-left-sidebar dashboard"{% endblock %}
+
 {% block content %}
 <style type="text/css">
-.module-info-popover, .section-info-popover{
-	cursor: pointer;
-	display:inline-block;
-	float: right;
-}
-.toggle-on{
-	display: block !important;
-}
-.toggle-off{
-	display: none;
-}
+    .module-info-popover, .section-info-popover {
+    	cursor: pointer;
+    	display:inline-block;
+    	float: right;
+    }
+    .toggle-on {
+    	display: block !important;
+    }
+    .toggle-off {
+    	display: none;
+    }
 </style>
 
 <h1 id="dashboard-header">Online Modules</h1>
 
-
 <div id="dashboard-toc">
-  <div id="modules">
-    {% for module in root.get_children %}
-	  <div class='module
+    <div id="modules">
+        {% for module in root.get_children %}
+	        <div class='module
 				{% for css in section_css %}
 		 			{% ifequal module.id css.section_css_id  %}
 		 				{{ css.css_field }}
 		 			{% endifequal %}
 		 		{% endfor %} dropdown'
-		  id="{{ module.id }}">
-	      {%for type in module_type%}
-	 		{% ifequal module.id type.module_type_id %}
-				<span class='hide {{ type.info }}'>&nbsp;</span>
-	 		{% endifequal %}
-		  {% endfor %}
-		  <a class="show-module dropdown-toggle" data-toggle="dropdown" rel="{{ module.get_absolute_url }}" href="javascript:void(0);">{{ module.label }}<span class="caret"></span></a>
-		  <div class="divclearfix"></div>
-		  <div class="show-descendants">
-		    <ul class="dropdown-menu">
-            {% for s in module.get_descendants %}
-              {% ifequal s.id module.id %}
-              {% else %}
-                <li class="menu-{{s.depth}}" style="list-style-type: none;">
-                  {% ifnotequal s.id section.id %}
-                    <a href="{{menu_base}}{{s.get_absolute_url}}">
-                  {% else %}
-                     <b>
-                  {% endifnotequal %}
-                    {{s.label}}
-                  {% ifnotequal s.id section.id %}
-                    </a>
-                  {% else %}
-                    </b>
-                  {% endifnotequal %}
-               {% if s.get_children %}<ul>{% else %}
-               {% if s.is_last_child %}</ul>{% endif %}{% endif %}
-                </li>
-               {% endifequal %}
-            {% endfor %}
-            </ul>
-          </div><!--end .show-descendants-->
-      </div><!--end .module-->
-    {% endfor %}
-  </div>
-  <div id="return"></div><!-- end #return -->
-  <div class="divclearfix"></div><!-- divclearfix -->
+		      id="{{ module.id }}">
+	        
+                {% for type in module_type %}
+    	 		    {% ifequal module.id type.module_type_id %}
+    				    <span class='hide {{ type.info }}'>&nbsp;</span>
+    	 		    {% endifequal %}
+                {% endfor %}
+            
+                <a class="show-module dropdown-toggle" data-toggle="dropdown"
+                    rel="{{ module.get_absolute_url }}" href="javascript:void(0);">
+                        {{ module.label }}<span class="caret"></span></a>
+    		  
+                <div class="divclearfix"></div>
+
+                <div class="show-descendants">
+                    <ul class="dropdown-menu">
+                        {% for s in module.get_descendants %}
+                            {% ifequal s.id module.id %}
+                            {% else %}
+                                <li class="menu-{{s.depth}}" style="list-style-type: none;">
+                                {% ifnotequal s.id section.id %}
+                                    <a href="{{menu_base}}{{s.get_absolute_url}}">
+                                {% else %}
+                                    <b>
+                                {% endifnotequal %}
+                                
+                                {{s.label}}
+                                
+                                {% ifnotequal s.id section.id %}
+                                    </a>
+                                {% else %}
+                                    </b>
+                                {% endifnotequal %}
+                   
+                                {% if s.get_children %}<ul>{% else %}
+                                {% if s.is_last_child %}</ul>{% endif %}{% endif %}
+                                </li>
+                            {% endifequal %}
+                        {% endfor %}
+                    </ul>
+                </div><!--end .show-descendants-->
+            </div><!--end .module-->
+        {% endfor %}
+    </div>
+    
+    <div id="return"></div><!-- end #return -->
+
+    <div class="divclearfix"></div><!-- divclearfix -->
+    
 </div><!-- end #dashboard-toc -->
 
-	<div class="modal hide" id="myModal">
-	  <div class="modal-header">
+<div class="modal hide" id="myModal">
+    <div class="modal-header">
 	    <button type="button" class="close" data-dismiss="modal">×</button>
 	    <h3>We appologize.</h3>
-	  </div>
-	  <div class="modal-body">
+	</div>
+    <div class="modal-body">
 	    <p>That course is not available. Please choose from one of the currently available modules.</p>
-	  </div>
-	</div><!--end #myModal-->
+	</div>
+</div><!--end #myModal-->
 
 <script src="{{STATIC_URL}}js/dashboard.js"></script>
+
 {% endblock %}

--- a/phtc/templates/main/dashboard.html
+++ b/phtc/templates/main/dashboard.html
@@ -31,45 +31,29 @@
 		 			{% endifequal %}
 		 		{% endfor %} dropdown'
 		      id="{{ module.id }}">
-	        
+
                 {% for type in module_type %}
     	 		    {% ifequal module.id type.module_type_id %}
     				    <span class='hide {{ type.info }}'>&nbsp;</span>
     	 		    {% endifequal %}
                 {% endfor %}
-            
+
                 <a class="show-module dropdown-toggle" data-toggle="dropdown"
                     rel="{{ module.get_absolute_url }}" href="javascript:void(0);">
                         {{ module.label }}<span class="caret"></span></a>
-    		  
+
                 <div class="divclearfix"></div>
 
                 <div class="show-descendants">
-                    <ul class="dropdown-menu">
+                    <div class="dropdown-menu">
                         {% for s in module.get_descendants %}
-                            {% ifequal s.id module.id %}
-                            {% else %}
-                                <li class="menu-{{s.depth}}" style="list-style-type: none;">
-                                {% ifnotequal s.id section.id %}
-                                    <a href="{{menu_base}}{{s.get_absolute_url}}">
-                                {% else %}
-                                    <b>
-                                {% endifnotequal %}
-                                
-                                {{s.label}}
-                                
-                                {% ifnotequal s.id section.id %}
-                                    </a>
-                                {% else %}
-                                    </b>
-                                {% endifnotequal %}
-                   
-                                {% if s.get_children %}<ul>{% else %}
-                                {% if s.is_last_child %}</ul>{% endif %}{% endif %}
-                                </li>
-                            {% endifequal %}
+                            <div class="menu-item menu-{{s.depth}}">
+                                <a href="{{menu_base}}{{s.get_absolute_url}}">
+                                    {{s.label}}
+                                </a>
+                            </div>
                         {% endfor %}
-                    </ul>
+                    </div>
                 </div><!--end .show-descendants-->
             </div><!--end .module-->
         {% endfor %}


### PR DESCRIPTION
The PHTC staging build is timing out on the mediacheck step. The speed bump is the 1st hierarchy descendant rendering. (Subsequent views are cached, and significantly speedier)
* Opt for `<div>` rather than `<ul><li>.` This eliminates the need for the `get_children`/`is_last_child ` queries.
* Style the `<div>s` based on menu depth, e.g. `menu-4` has `margin-left: 20px;`
* Eliminate the section highlight as it's not applicable in this screen

Metrics
Before: 640 queries / 7562ms
After: 450 queries / 4828ms

This [PR](https://github.com/ccnmtl/django-pagetree/pull/126) once added to the project with these changes shows even better results: After: 260 queries / 3086.51ms

Note: Review the [2nd commit](https://github.com/ccnmtl/phtc/commit/de74862f85cca97d9d7daa65aea52f66e12c5be8) as the first simply cleaned up formatting.