### PR TITLE
Fix Checkbox Activity - loadStyles

### DIFF
--- a/media/css/checkbox_activity.css
+++ b/media/css/checkbox_activity.css
@@ -1,9 +1,9 @@
-
-.checkbox-wrapper table{
+.checkbox-wrapper table {
   border: none !important;
   margin: 14px 0 50px 0;
 }
-.checkbox-wrapper table td{
+
+.checkbox-wrapper table td {
 	border: 1px solid #333;
 	/*background: #e2e2e2;*/
 	min-width: 65px;
@@ -12,24 +12,29 @@
 	padding: 0 10px;
   color: #333;
 }
-.column-header{
+
+.checkbox-wrapper .column-header {
 	height: 25px;
 }
-.column-spacer{
+
+.checkbox-wrapper .column-spacer {
   border: none !important;
   background: none !important;
 }
-.interactive{
-	cursor: pointer;
-  background:#FFF!important;
+
+.checkbox-wrapper .interactive {
+    cursor: pointer;
+    background:#FFF!important;
 }
-.user-x{
+
+.checkbox-wrapper .user-x {
   color: #08C !important;
   font-weight: bold;
   padding: 0 0 0 0px !important;
   font-size: 24px;
 }
-.answr-x{
+
+.checkbox-wrapper .answr-x {
   margin: -3px 0 0 0;
   color: #333 !important;
   font-weight: bold;
@@ -37,7 +42,8 @@
   font-size: 24px;
   float: right;
 }
-#row-title{
+
+.checkbox-wrapper #row-title {
   float: left;
   margin: 170px 0 0 0;
   font-weight: bold;
@@ -45,32 +51,38 @@
   padding: 0 10px;
   color:#C63;
 }
-#column-title{
+
+.checkbox-wrapper #column-title {
   color:#C63;
   font-weight: bold;
   text-transform: uppercase;
   text-align: center;
 }
-.answer-key-wrapper{
+
+.checkbox-wrapper .answer-key-wrapper {
     position: absolute;
     margin: -35px 0 0 239px;
     clear: both;
     padding: 4px;
     border: 1px solid #999;
 }
-.user-answers{
+
+.checkbox-wrapper .user-answers {
   float: left;
   line-height: 20px;
 }
-.activity-answers{
+
+.checkbox-wrapper .activity-answers {
   float: right;
   padding: 0 0 0 40px;
   line-height: 20px;
   margin: 3px 0 0 0
 }
-.clear-button{
+
+.checkbox-wrapper .clear-button {
   margin: 0 30px;
 }
-.submit-button{
+
+.checkbox-wrapper .submit-button {
   margin:0 30px;
 }

--- a/media/js/checkbox_activity/js/activity.js
+++ b/media/js/checkbox_activity/js/activity.js
@@ -81,7 +81,7 @@ function CheckboxActivity($, context) {
                 table.append(tr);
             } else {
                 var columnRow = $('<tr class="column-row"/>');
-                //insert a spacer ciolumn to account for the row headers
+                //insert a spacer column to account for the row headers
                 columnRow.append('<td class="column-spacer">&nbsp;</td>');
                 objs.each(function(k) {
                     var obj = objs[k];
@@ -215,18 +215,8 @@ function CheckboxActivity($, context) {
         $('.checkbox-wrapper').append(html);
     };
 
-    this.loadStyles = function($) {
-        // this will need to change depending on how the activity is
-        // installed into your site. Just refence the relatice location
-        // of the checkbox_activity styles.css
-        var myStylesLocation = '/media/js/checkbox_activity/styles.css';
-        $('<style type="text/css">@import url("' +
-          myStylesLocation + '")</style>')
-            .appendTo('head');
-    };
-
     // A custom function that allows for stuff that is specific to the
-    // site that the activity is ebedded into.
+    // site that the activity is embedded into.
     this.customEmbed = function(command) {
         if (command === 'hide') {
             $('.pager').css({
@@ -241,7 +231,6 @@ function CheckboxActivity($, context) {
 
     //initialize the activity
     this.createMatches(this.attrs, this.objects);
-    this.loadStyles($);
 }
 $(document).ready(function() {
     // create new Checkbox - the arguments are jQuery and

--- a/phtc/templates/main/page.html
+++ b/phtc/templates/main/page.html
@@ -11,6 +11,7 @@
 {% for block in section.pageblock_set.all %}
 {% rendercss block %}
 {% endfor %}
+    <link rel="stylesheet" href="{{STATIC_URL}}css/checkbox_activity.css" type="text/css" media="all" />
 {% endblock %}
 
 {% block title %}{{section.label}}{% endblock %}


### PR DESCRIPTION
This functionality was implemented purely in javascript rather than using the pageblock mechanism.

The loadStyles approach breaks with the AWS conversion and is not easily fixable without hard-coding the styles url.

To resolve for the moment, restrict the styles to this activity and load in page.html.