### PR TITLE
remove tagging

### DIFF
--- a/phtc/settings_shared.py
+++ b/phtc/settings_shared.py
@@ -20,7 +20,6 @@ TEMPLATE_CONTEXT_PROCESSORS += [  # noqa
 
 INSTALLED_APPS += [  # noqa
     'sorl.thumbnail',
-    'tagging',
     'typogrify',
     'bootstrapform',
     'phtc.main',

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,6 @@ pyOpenSSL==0.15.1
 ndg-httpsclient==0.4.0
 djangowind==0.14.3
 sorl==3.1
-tagging==0.3-pre
 typogrify==2.0.7
 raven==5.12.0
 contextlib2==0.5.1


### PR DESCRIPTION
appears to be unused and is blocking the path to django 1.9