### PR TITLE
add django-bootstrap3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,7 @@ django-annoying==0.9.0
 django-compressor==2.0
 django-statsd-mozilla==0.3.16
 django-bootstrap-form==3.2.1
+django-bootstrap3==7.0.1
 django-debug-toolbar==1.4
 django-treebeard==4.0.1
 django-pagetree==1.1.15


### PR DESCRIPTION
required by some pagetree templates