### PR TITLE
Add bootstrap3 to INSTALLED_APPS.

### DIFF
--- a/phtc/settings_shared.py
+++ b/phtc/settings_shared.py
@@ -21,6 +21,7 @@ TEMPLATES[0]['OPTIONS']['context_processors'].append(  # noqa
 INSTALLED_APPS += [  # noqa
     'sorl.thumbnail',
     'typogrify',
+    'bootstrap3',
     'bootstrapform',
     'phtc.main',
     'pagetree',


### PR DESCRIPTION
django-pagetree requires this - should fix a jenkins error.
django-bootstrap3 is listed in requirements.txt here but missing from
INSTALLED_APPS.